### PR TITLE
Add bash shell completion instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,10 @@ For example, with fish, put this in your ``~/.config/fish/completions/pipenv.fis
 
     eval (pipenv --completion)
 
+Alternatively, with bash, put this in your ``.bashrc`` or ``.bash_profile``::
+
+    eval "$(pipenv --completion)"
+
 Magic shell completions are now enabled! There is also a `fish plugin <https://github.com/fisherman/pipenv>`_, which will automatically activate your subshells for you!
 
 Fish is the best shell. You should use it.


### PR DESCRIPTION
The fish shell is great, but bash is still a popular shell in use by many people.  I thought it would be useful to include instructions to setup auto-completion in bash in the readme.